### PR TITLE
Use Buffer.concat instead of string concat

### DIFF
--- a/client/node.js
+++ b/client/node.js
@@ -95,7 +95,7 @@
 
 				clientResponse.on('end', function () {
 					// Create the final response entity
-					response.entity = buffers.length > 0 ? Buffer.concat(buffers) : '';
+					response.entity = buffers.length > 0 ? Buffer.concat(buffers).toString() : '';
 					buffers = null;
 
 					d.resolve(response);


### PR DESCRIPTION
[Supposedly](http://www.maurer.me/articles/nodejs-string-building-buffers-arrays-and-concatenation/2011112001/), collecting an array of buffers as `'data'` events are emitted, and then using [`Buffer.concat`](http://nodejs.org/api/buffer.html#buffer_class_method_buffer_concat_list_totallength) to concatenate the whole lot once you've received the `'end'` event is more efficient (time and space) than [using `+=` to concat strings](https://github.com/s2js/rest/blob/master/client/node.js#L93).  Might be a nice, simple optimization.
