### PR TITLE
+ from mime normalize removed,

### DIFF
--- a/mime/registry.js
+++ b/mime/registry.js
@@ -16,7 +16,7 @@
 
 		function normalizeMime(mime) {
 			// TODO we're dropping info that may be important
-			return mime.split(/[;\+]/)[0].trim();
+			return mime.split(/[;]/)[0].trim();
 		}
 
 		function Registry(parent) {


### PR DESCRIPTION
the +in the mime type is important and should not be omitted, we have faced the problem when registering interceptor for application/sparql-results+json and application/sparql-results+xml. it could not differentiate the two types.
Mime like: application/ld+json work correctly.