### PR TITLE
Add moduleType to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
 	"name": "rest",
 	"version": "1.0.2",
 	"main": "./rest.js",
+	"moduleType": ["amd", "node"],
 	"dependencies": {
 		"when": "~2"
 	},


### PR DESCRIPTION
This became official in bower 1.3.1. See bower/bower#934.  It's an array (see the commit there that lists it as a "checkbox" type question for `bower init`, and I tried it with bower 1.3.1 to be sure), and the idea is to list both "amd" and "node" for UMD formatted packages.

PRing this against master instead of dev because I'm hoping for a quick hotfix that'll unblock me on something I'm working on :)
