### PR TITLE
Bugfix for cyclic HATEOAS

### DIFF
--- a/interceptor/hateoas.js
+++ b/interceptor/hateoas.js
@@ -117,7 +117,7 @@
 					apply(response.links, parseLinkHeaders(response.headers.Link));
 				}
 
-				find.findProperties(response, 'links', function (obj, host) {
+				find.findProperties(response.entity, 'links', function (obj, host) {
 					var target;
 
 					if (Array.isArray(host.links)) {


### PR DESCRIPTION
Hi Scott,

having some cyclic issues when playing around with the HATEOAS interceptor.
Only checking the `response.entity` rather then the `response` seems too fix it.

Btw, love the extensibility of this project. Composing clients with these interceptors are pure magic :+1: 
