### PR TITLE
enable configuring of nodejs https options

### DIFF
--- a/client/node.js
+++ b/client/node.js
@@ -71,9 +71,17 @@
 				}
 
 				url = new UrlBuilder(request.path || '', request.params).build();
-				client = url.match(httpsExp) ? https : http;
+				var isHttps = url.match(httpsExp);
+				client = isHttps ? https : http;
 
 				options = parser.parse(url);
+
+				if (isHttps && request.httpsOptions) {
+					Object.keys(request.httpsOptions).forEach(function (option) {
+						options[option] = request.httpsOptions[option];
+					});
+				}
+
 				entity = request.entity;
 				request.method = request.method || (entity ? 'POST' : 'GET');
 				options.method = request.method;


### PR DESCRIPTION
Hi,

I noticed that there is currently no possiblity to provide additional configuration for https requests in nodejs.

See the nodejs manual here: http://nodejs.org/docs/latest/api/https.html#https_https_request_options_callback

With this pull request, it is possible to configure the extended tls.connect configuration options. I needed this because I wanted to to a request against a https backend without a valid ssl cert. Now I can do a request with the `rejectUnauthorized` configuration option like in this example

``` js
client({ 
  path: '/data.json',
  httpsOptions: {
    rejectUnauthorized: false
  }
}
).then(...
```
