### PR TITLE
Use window as default global

### DIFF
--- a/client/xhr.js
+++ b/client/xhr.js
@@ -144,6 +144,6 @@
 
 }(
 	typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); },
-	this
+	typeof window === 'undefined' ? this : window
 	// Boilerplate for AMD and Node
 ));


### PR DESCRIPTION
In a CommonJS environment `this` references the module, not the `window`. Thus, when using rest with something like Browserify the XHR adapter is not able to find `XMLHttpRequest`. This patch addresses this issue.
