### PR TITLE
Simplify promise usage in registry

### DIFF
--- a/mime/registry.js
+++ b/mime/registry.js
@@ -76,30 +76,14 @@
 		};
 
 		function loadAMD(mime) {
-			var timeout;
-
 			return when.promise(function (resolve, reject) {
-
 				// HOPE reject on a local require would be nice
-				timeout = setTimeout(reject, 1000);
 				require(['./type/' + mime], resolve, reject);
-
-			}).otherwise(function (ex) {
-				return when.reject(ex || new Error('Timeout while loading mime module: ' + mime));
-			}).ensure(function () {
-				clearTimeout(timeout);
-			});
+			}).timeout(1000);
 		}
 
 		function loadNode(mime) {
-			return when.promise(function (resolve, reject) {
-				try {
-					resolve(require('./type/' + mime));
-				}
-				catch (e) {
-					reject(e);
-				}
-			});
+			return when.attempt(require, './type/' + mime);
 		}
 
 		registry = new Registry(typeof define === 'function' && define.amd ? loadAMD : loadNode);


### PR DESCRIPTION
1. Use using promise.timeout rather than setTimeout to do the registry AMD load timeout.
2. Use `when.attempt` to execute `require` safely (so it always returns a promise).

I don't think I changed any of the semantics.  Unit tests pass, but def double check the timeout case to make sure I got it right :)  It'd be nice to pattern match on `when.TimeoutError` (or perhaps simply let it go through), but that was introduced in 3.2, so I don't think rest.js can rely on that yet.
