### PR TITLE
Ability to disable cancellation of timed out requests.

### DIFF
--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -782,7 +782,7 @@ client({}).then(
 
 `rest/interceptor/timeout` ([src](../interceptor/timeout.js))
 
-Rejects a request that takes longer than the timeout.  If a request is in-flight, it is canceled.  The timeout value may be specified in the request or the interceptor config.
+Rejects a request that takes longer than the timeout.  If a request is in-flight, it is canceled by default.  The timeout value may be specified in the request or the interceptor config.
 
 **Phases**
 
@@ -803,6 +803,12 @@ Rejects a request that takes longer than the timeout.  If a request is in-flight
   <td>optional</td>
   <td><em>disabled</em></td>
   <td>duration in milliseconds before canceling the request. Non-positive values disable the timeout.</td>
+</tr>
+<tr>
+  <td>transient</td>
+  <td>optional</td>
+  <td>false</td>
+  <td>disables the cancellation of timed out requests, allowing additional interceptors to gracefully handle the timeout.</td>
 </tr>
 </table>
 

--- a/interceptor/timeout.js
+++ b/interceptor/timeout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors
+ * Copyright 2012-2015 the original author or authors
  * @license MIT, see LICENSE.txt for details
  *
  * @author Jeremy Grelle
@@ -30,19 +30,22 @@
 				return config;
 			},
 			request: function (request, config) {
-				var timeout, abortTrigger;
+				var timeout, abortTrigger, transient;
 				timeout = 'timeout' in request ? request.timeout : config.timeout;
+				transient = 'transient' in request ? request.transient : config.transient;
 				if (timeout <= 0) {
 					return request;
 				}
 				abortTrigger = when.defer();
 				this.timeout = setTimeout(function () {
 					abortTrigger.reject({ request: request, error: 'timeout' });
-					if (request.cancel) {
-						request.cancel();
-					}
-					else {
-						request.canceled = true;
+					if (!transient) {
+						if (request.cancel) {
+							request.cancel();
+						}
+						else {
+							request.canceled = true;
+						}
 					}
 				}, timeout);
 				return new interceptor.ComplexRequest({ request: request, abort: abortTrigger.promise });

--- a/test/interceptor/timeout-test.js
+++ b/test/interceptor/timeout-test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2014 the original author or authors
+ * Copyright 2012-2015 the original author or authors
  * @license MIT, see LICENSE.txt for details
  *
  * @author Jeremy Grelle
@@ -126,6 +126,36 @@
 						assert.same(request, response.request);
 						assert.equals('timeout', response.error);
 						assert(request.canceled);
+					})
+				);
+				refute(request.canceled);
+				return response;
+			},
+			'should not cancel request if transient config enabled': function () {
+				var client, request, response;
+				client = timeout(cancelableClient, { timeout: 11, transient: true });
+				request = {};
+				response = client(request).then(
+					fail,
+					failOnThrow(function (response) {
+						assert.same(request, response.request);
+						assert.equals('timeout', response.error);
+						refute(request.canceled);
+					})
+				);
+				refute(request.canceled);
+				return response;
+			},
+			'should use request transient value rather then interceptor': function () {
+				var client, request, response;
+				client = timeout(cancelableClient, { timeout: 11, transient: false });
+				request = { transient: true };
+				response = client(request).then(
+					fail,
+					failOnThrow(function (response) {
+						assert.same(request, response.request);
+						assert.equals('timeout', response.error);
+						refute(request.canceled);
 					})
 				);
 				refute(request.canceled);


### PR DESCRIPTION
Adds a "transient" property to the timeout interceptor.
When set to true, timed out request will not be cancelled.
This allows other interceptors to handle timeouts gracefully.

Issue: #94