### PR TITLE
Allow to use XHR within Webworker scope

### DIFF
--- a/client/xhr.js
+++ b/client/xhr.js
@@ -169,6 +169,6 @@
 
 }(
 	typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); },
-	typeof window !== 'undefined' ? window : void 0
+	typeof (window || self) !== 'undefined' ? window || self : void 0
 	// Boilerplate for AMD and Node
 ));


### PR DESCRIPTION
At the moment you can't use XHR if you load restClient within a worker instance. I extend global definition to fallback to self instead of window.