### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,7 @@
 	"version": "1.3.1",
 	"description": "RESTful HTTP client library",
 	"keywords": ["rest", "http", "client", "rest-template", "spring", "cujojs"],
-	"licenses": [
-		{
-			"type": "MIT",
-			"url": "http://opensource.org/licenses/MIT"
-		}
-	],
+	"license": "MIT",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/cujojs/rest.git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/