### PR TITLE
add errorTransform interceptor with tests and docs

### DIFF
--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -15,6 +15,7 @@
         - [CSRF Interceptor](#module-rest/interceptor/csrf)
     - [Error Detection and Recovery Interceptors](#interceptor-provided-error)
         - [Error Code Interceptor](#module-rest/interceptor/errorCode)
+        - [Error Transform Interceptor](#module-rest/interceptor/errorTransform)
         - [Retry Interceptor](#module-rest/interceptor/retry)
         - [Timeout Interceptor](#module-rest/interceptor/timeout)
     - [Fallback Interceptors](#interceptor-provided-fallback)
@@ -713,6 +714,56 @@ client({}).then(
     },
     function (response) {
         assert.same(500, response.status.code);
+    }
+);
+```
+
+
+<a name="module-rest/interceptor/errorTransform"></a>
+#### Error Transform Interceptor
+
+`rest/interceptor/errorTransform` ([src](../interceptor/errorTransform.js))
+
+Allows transformation of an error response through use of a `transform` configuration function.
+This is useful for transforming the entity of an error response into an Error object, among other
+uses.
+
+**Phases**
+
+- error
+
+**Configuration**
+
+<table>
+<tr>
+  <th>Property</th>
+  <th>Required?</th>
+  <th>Default</th>
+  <th>Description</th>
+</tr>
+<tr>
+  <td>transform</td>
+  <td>optional</td>
+  <td>noop</td>
+  <td>function that returns a new response object</td>
+</tr>
+</table>
+
+**Example**
+
+```javascript
+function transform (response) {
+  response.entity = new Error(response.entity.message);
+  return response;
+}
+
+client = rest.wrap(errorTransform, { transform: transform });
+client({}).then(
+    function (response) {
+        // not called
+    },
+    function (response) {
+        assert.equals(response.entity instanceof Error, true);
     }
 );
 ```

--- a/interceptor/errorTransform.js
+++ b/interceptor/errorTransform.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012-2013 the original author or authors
+ * @license MIT, see LICENSE.txt for details
+ *
+ * @author Blaine Bublitz
+ */
+
+(function (define) {
+  'use strict';
+
+  define(function (require) {
+
+    var interceptor, when;
+
+    interceptor = require('../interceptor');
+    when = require('when');
+
+    function noopTransform (response) {
+      return response;
+    }
+
+    /**
+     * Modifies an error response using a transform function.
+     * Useful for turning JSON responses into Error objects.
+     *
+     * @param {Client} [client] client to wrap
+     * @param {number} [config.tranform=<noop>] transform function returns a modified response
+     *
+     * @returns {Client}
+     */
+    return interceptor({
+      init: function (config) {
+        config.transform = config.transform || noopTransform;
+        return config;
+      },
+      error: function (response, config) {
+        return when.reject(config.transform(response));
+      }
+    });
+
+  });
+
+}(
+  typeof define === 'function' && define.amd ? define : function (factory) { module.exports = factory(require); }
+  // Boilerplate for AMD and Node
+));

--- a/test/interceptor/errorTransform-test.js
+++ b/test/interceptor/errorTransform-test.js
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2012-2014 the original author or authors
+ * @license MIT, see LICENSE.txt for details
+ *
+ * @author Blaine Bublitz
+ */
+
+(function (buster, define) {
+	'use strict';
+
+	var assert, refute, fail, failOnThrow;
+
+	assert = buster.assertions.assert;
+	refute = buster.assertions.refute;
+	fail = buster.assertions.fail;
+	failOnThrow = buster.assertions.failOnThrow;
+
+	define('rest/interceptor/errorTransform-test', function (require) {
+
+		var errorTransform, rest, when;
+
+		errorTransform = require('rest/interceptor/errorTransform');
+		rest = require('rest');
+		when = require('when');
+
+		buster.testCase('rest/interceptor/errorTransform', {
+			'should leave the response alone by default': function () {
+				var originalResponse;
+				var client = errorTransform(
+					function (request) {
+						originalResponse = { request: request, error: 'Thrown by fake client' };
+						return when.reject(originalResponse);
+					}
+				);
+				return client({}).then(
+					fail,
+					failOnThrow(function (response) {
+						assert.equals(response, originalResponse);
+					})
+				);
+			},
+			'should transform an error response with a custom transform function': function () {
+				function transform (response) {
+					response.entity = new Error(response.entity.message);
+					return response;
+				}
+
+				var client = errorTransform(
+					function (request) {
+						return when.reject({ request: request, entity: { message: 'Thrown by fake client' } });
+					},
+					{ transform: transform }
+				);
+				return client({}).then(
+					fail,
+					failOnThrow(function (response) {
+						assert.equals(response.entity instanceof Error, true);
+					})
+				);
+			},
+			'should have the default client as the parent by default': function () {
+				assert.same(rest, errorTransform().skip());
+			},
+			'should support interceptor warpping': function () {
+				assert(typeof errorTransform().wrap === 'function');
+			}
+		});
+
+	});
+
+}(
+	this.buster || require('buster'),
+	typeof define === 'function' && define.amd ? define : function (id, factory) {
+		var packageName = id.split(/[\/\-]/)[0], pathToRoot = id.replace(/[^\/]+/g, '..');
+		pathToRoot = pathToRoot.length > 2 ? pathToRoot.substr(3) : pathToRoot;
+		factory(function (moduleId) {
+			return require(moduleId.indexOf(packageName) === 0 ? pathToRoot + moduleId.substr(packageName.length) : moduleId);
+		});
+	}
+	// Boilerplate for AMD and Node
+));


### PR DESCRIPTION
@scothis Not sure if you want this to be in core or for me to make it an external module, but I figured I would send it your way first.  This interceptor would allow the 1.x branch to work around some of the weirder error edge cases for a response.
