### PR TITLE
Fix template expansion when an array value is not first a list of parameters

### DIFF
--- a/test/util/uriTemplate-test.js
+++ b/test/util/uriTemplate-test.js
@@ -156,6 +156,10 @@
           assert.same(uriTemplate.expand('{;list*}', params), ';list=red;list=green;list=blue')
           assert.same(uriTemplate.expand('{;keys}', params), ';keys=semi,%3B,dot,.,comma,%2C')
           assert.same(uriTemplate.expand('{;keys*}', params), ';semi=%3B;dot=.;comma=%2C')
+          assert.same(uriTemplate.expand('{;who,list}', params), ';who=fred;list=red,green,blue')
+          assert.same(uriTemplate.expand('{;who,list*}', params), ';who=fred;list=red;list=green;list=blue')
+          assert.same(uriTemplate.expand('{;who,keys}', params), ';who=fred;keys=semi,%3B,dot,.,comma,%2C')
+          assert.same(uriTemplate.expand('{;who,keys*}', params), ';who=fred;semi=%3B;dot=.;comma=%2C')
         },
         '3.2.8. Form-Style Query Expansion: {?var}': function () {
           assert.same(uriTemplate.expand('{?who}', params), '?who=fred')
@@ -168,6 +172,10 @@
           assert.same(uriTemplate.expand('{?list*}', params), '?list=red&list=green&list=blue')
           assert.same(uriTemplate.expand('{?keys}', params), '?keys=semi,%3B,dot,.,comma,%2C')
           assert.same(uriTemplate.expand('{?keys*}', params), '?semi=%3B&dot=.&comma=%2C')
+          assert.same(uriTemplate.expand('{?who,list}', params), '?who=fred&list=red,green,blue')
+          assert.same(uriTemplate.expand('{?who,list*}', params), '?who=fred&list=red&list=green&list=blue')
+          assert.same(uriTemplate.expand('{?who,keys}', params), '?who=fred&keys=semi,%3B,dot,.,comma,%2C')
+          assert.same(uriTemplate.expand('{?who,keys*}', params), '?who=fred&semi=%3B&dot=.&comma=%2C')
         },
         '3.2.9. Form-Style Query Continuation: {&var}': function () {
           assert.same(uriTemplate.expand('{&who}', params), '&who=fred')
@@ -181,6 +189,10 @@
           assert.same(uriTemplate.expand('{&list*}', params), '&list=red&list=green&list=blue')
           assert.same(uriTemplate.expand('{&keys}', params), '&keys=semi,%3B,dot,.,comma,%2C')
           assert.same(uriTemplate.expand('{&keys*}', params), '&semi=%3B&dot=.&comma=%2C')
+          assert.same(uriTemplate.expand('{&who,list}', params), '&who=fred&list=red,green,blue')
+          assert.same(uriTemplate.expand('{&who,list*}', params), '&who=fred&list=red&list=green&list=blue')
+          assert.same(uriTemplate.expand('{&who,keys}', params), '&who=fred&keys=semi,%3B,dot,.,comma,%2C')
+          assert.same(uriTemplate.expand('{&who,keys*}', params), '&who=fred&semi=%3B&dot=.&comma=%2C')
         }
       },
 


### PR DESCRIPTION
**Problem**
There is a bug in the current `uriTemplate` implementation that causes the falling test to fail:
`assert.same(uriTemplate.expand('{?who,list}', params), '?who=fred&list=red,green,blue');`

In the current code, `uriTemplate.expand('{?who,list}', params)` will return `'?who=fred,red,green,blue'`.

This is due to the code:

```
if (Array.isArray(value)) {
    if (result.length) {
```

If `list` is not the first parameter in a comma-separated list of parameters, then the result of this code is that the values of `list` get appended to `who`, because the variable `result` is already defined with the value `?who=fred`

**Solution**
This PR changes `uriTemplate.js` to store the result of each pass in an array, then joins the values using the operation separator before returning the final value.

This removes the need for various `if (result.length)` checks in the code by using an `Array.join` at the end of the loop.

**Tests**
This PR adds four test cases to verify the result of a query parameter expansion when a list or object value is preceded by another parameter.

All existing tests continue to pass unmodified.
