### PR TITLE
Issue #119

### DIFF
--- a/util/responsePromise.js
+++ b/util/responsePromise.js
@@ -15,7 +15,7 @@ function property (promise, name) {
       return value && value[name]
     },
     function (value) {
-      return Promise.reject(value && value[name])
+      return Promise.reject(value && value[name] || value)
     }
   )
 }


### PR DESCRIPTION
If a reject happens after `.entity()` is called, argument is undefined. #119
