### PR TITLE
Add node https proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Contributors
 - Jeremy Grelle <jeremy.grelle@gmail.com>
 - John Hann <john@unscriptable.com>
 - Michael Jackson <mjijackson@gmail.com>
+- Sander Remie <user@rmi7.me>
 
 Please see CONTRIBUTING.md for details on how to contribute to this project.
 
@@ -226,7 +227,7 @@ Please see CONTRIBUTING.md for details on how to contribute to this project.
 Copyright
 ---------
 
-Copyright 2012-2016 the original author or authors
+Copyright 2012-2017 the original author or authors
 
 rest.js is made available under the MIT license.  See LICENSE.txt for details.
 
@@ -237,6 +238,7 @@ Change Log
 .next
 - Cancel requests via the `cancel` method on the response promise
 - Switch linter to eslint and the JavaScript Standard Style rules
+- add HTTPS proxy support for the node client by using npm module `https-proxy-agent`
 
 2.0.0
 - MAJOR: Drop hard when.js dependency in favor of ES6 Promise API. See https://github.com/cujojs/when/blob/master/docs/es6-promise-shim.md to use when.js as an ES6 Promise polyfill.

--- a/client/default.js
+++ b/client/default.js
@@ -53,7 +53,7 @@
 
  /**
   * Extended when.js Promises/A+ promise with HTTP specific helpers
-  *q
+  *
   * @method entity promise for the HTTP entity
   * @method status promise for the HTTP status code
   * @method headers promise for the HTTP response headers

--- a/client/node.js
+++ b/client/node.js
@@ -1,9 +1,10 @@
 /*
- * Copyright 2012-2016 the original author or authors
+ * Copyright 2012-2017 the original author or authors
  * @license MIT, see LICENSE.txt for details
  *
  * @author Jeremy Grelle
  * @author Scott Andrews
+ * author Sander Remie
  */
 
 'use strict'
@@ -84,6 +85,10 @@ module.exports = client(function node (request) {
       response.error = 'canceled'
       clientRequest.abort()
       reject(response)
+    }
+
+    if (request.agent) {
+        options.agent = request.agent;
     }
 
     var clientRequest = client.request(options, function (clientResponse) {

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -509,6 +509,47 @@ client({ path: '/dictionary/{term}', params: { term: 'hypermedia' } }).then(func
 });
 ```
 
+<a name="module-rest/interceptor/https-proxy"></a>
+#### Proxy Interceptor
+
+`rest/interceptor/httpsProxy` ([src](../interceptor/httpsProxy.js))
+
+**This only works with the node client (`rest/client/node`)**
+Creates a https proxy agent that will proxy the request through the given proxy. If a url is provided, this url will be used to create a
+`https-proxy-agent`, which will be saved in `request.agent`. The node client checks if `request.agent` exists, if it does it will send the request
+through the proxy.
+
+**Phases**
+
+- request
+
+**Configuration**
+
+<table>
+<tr>
+  <th>Property</th>
+  <th>Required?</th>
+  <th>Default</th>
+  <th>Description</th>
+</tr>
+<tr>
+  <td>url</td>
+  <td>optional</td>
+  <td><em>empty string</em></td>
+  <td>url of the proxy to use</td>
+</tr>
+</table>
+
+**Example**
+
+```javascript
+client = rest.wrap(httpsProxy, { url: 'http://127.0.0.1:3128' });
+client({ method: 'POST', path: 'http://example.com/messages', entity: 'hello world' }).then(function (response) {
+
+    assert.same('http://127.0.0.1:3128/', response.request.agent.proxy.href);
+});
+```
+
 
 <a name="interceptor-provided-auth"></a>
 ### Authentication Interceptors
@@ -1096,6 +1137,7 @@ The interceptors provided with rest.js provide are also good examples.  Here are
 - [rest/interceptor/defaultRequest](#module-rest/interceptor/defaultRequest)
 - [rest/interceptor/mime](#module-rest/interceptor/mime)
 - [rest/interceptor/hateoas](#module-rest/interceptor/hateoas)
+- [rest/interceptor/httpsProxy](#module-rest/interceptor/httpsProxy)
 
 <a name="interceptor-custom-concepts-config"></a>
 **Config Initialization**

--- a/interceptor/httpsProxy.js
+++ b/interceptor/httpsProxy.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors
+ * @license MIT, see LICENSE.txt for details
+ *
+ * @author Sander Remie
+ * @since 2.0.1-pre
+ */
+
+'use strict';
+
+var interceptor, nodeClient, HttpsProxyAgent;
+
+interceptor = require('../interceptor');
+nodeClient = require('../client/node');
+HttpsProxyAgent = require('https-proxy-agent');
+
+/**
+ * Add support for using an HTTPS proxy in node
+ *
+ * Values provided to this interceptor are added to the request, if the
+ * request dose not already contain the property.
+ *
+ * The rest/client/node client is used by default instead of the
+ * common default client for the platform. This is because the module
+ * that is used for proxying is a node js module, so this will only work
+ * on node
+ *
+ * @param {Client} [client=rest/client/node] custom client to wrap
+ * @param {string} [config.url] the url of the proxy, e.g. http://127.0.0.1:3128
+ *
+ * @returns {Client}
+ */
+module.exports = interceptor({
+    client: nodeClient,
+    init: function (config) {
+        config.url = config.url || undefined;
+        return config;
+    },
+    request: function (request, config) {
+        if (config.url) {
+            request.agent = new HttpsProxyAgent(config.url);
+        }
+        return request;
+    }
+});

--- a/package.json
+++ b/package.json
@@ -35,9 +35,15 @@
     {
       "name": "Michael Jackson",
       "web": "https://github.com/mjackson"
+    },
+    {
+      "name": "Sander Remie",
+      "web": "https://github.com/rmi7"
     }
   ],
-  "dependencies": {},
+  "dependencies": {
+    "https-proxy-agent": "^1.0.0"
+  },
   "devDependencies": {
     "curl": "https://github.com/cujojs/curl/tarball/0.7.3",
     "eslint": "^2.13.1",

--- a/test/interceptor/httpsProxy-test.js
+++ b/test/interceptor/httpsProxy-test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 the original author or authors
+ * @license MIT, see LICENSE.txt for details
+ *
+ * @author Sander Remie
+ */
+
+(function (buster, define) {
+	'use strict';
+
+	var assert, refute, fail;
+
+	assert = buster.assertions.assert;
+	refute = buster.assertions.refute;
+	fail = buster.assertions.fail;
+
+	define('rest-test/interceptor/httpsProxy-test', function (require) {
+
+		var httpsProxy, rest, nodeClient, when;
+
+		httpsProxy = require('rest/interceptor/httpsProxy');
+		nodeClient = require('rest/client/node');
+		rest = require('rest');
+		when = require('when');
+
+		buster.testCase('rest/interceptor/httpsProxy', {
+			'should add agent option if proxy url is set': function () {
+				var client = httpsProxy(
+					function (request) { return { request: request }; },
+					{ url: 'http://127.0.0.1:3128' }
+				);
+				return client({}).then(function (response) {
+					assert.equals('http://127.0.0.1:3128/', response.request.agent.proxy.href);
+				})['catch'](fail);
+			},
+			'should support interceptor wrapping': function () {
+				assert(typeof httpsProxy().wrap === 'function');
+			}
+		});
+
+	});
+
+}(
+	this.buster || require('buster'),
+	typeof define === 'function' && define.amd ? define : function (id, factory) {
+		var packageName = id.split(/[\/\-]/)[0], pathToRoot = id.replace(/[^\/]+/g, '..');
+		pathToRoot = pathToRoot.length > 2 ? pathToRoot.substr(3) : pathToRoot;
+		factory(function (moduleId) {
+			return require(moduleId.indexOf(packageName) === 0 ? pathToRoot + moduleId.substr(packageName.length) : moduleId);
+		});
+	}
+	// Boilerplate for AMD and Node
+));


### PR DESCRIPTION
We (fintech company) would like to use an HTTPS proxy when performing rest calls. Therefore we need to be able to use an HTTPS proxy with this module. So I've added it.

I've tried to follow the `CONTRIBUTING` guidelines (added tests and added the necessary documentation)

If anything is missing or wrong please do tell and I will fix/improve it.