### PR TITLE
Fix IE 10/11 issue with `XMLHttpRequest.send(undefined)`

### DIFF
--- a/client/xhr.js
+++ b/client/xhr.js
@@ -147,6 +147,10 @@ module.exports = client(function xhr (request) {
         // IE 6 will not support error handling
       }
 
+      if (entity === undefined) {
+				entity = null;
+			}
+
       client.send(entity)
     } catch (e) {
       response.error = 'loaderror'


### PR DESCRIPTION
Fix IE 10/11 issue with `XMLHttpRequest.send(undefined)`
Fixes an issue where `client` would call `XMLHttpRequest.send(undefined)`, causing an issue in Internet Explorer 10 and 11. In these browsers, `XMLHttpRequest.send(undefined)` will cause a request body of "undefined" to be sent by the browser (e.g. on a POST). This causes the `XMLHttpRequest` to assume a request body of type `text/plain` (as Content-Type), which confuses some server software.

Before this change, calling `client` without supplying a request body would cause a call to `XMLHttpRequest.send(undefined)`. After the change, `client` calls `XMLHttpRequest.send(data)` if data is defined for the request, or `XMLHttpRequest.send(null)` if no data is defined.