### PR TITLE
Overwrites config params with request params

### DIFF
--- a/interceptor/template.js
+++ b/interceptor/template.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors
+ * Copyright 2015-2018 the original author or authors
  * @license MIT, see LICENSE.txt for details
  *
  * @author Scott Andrews
@@ -34,7 +34,7 @@ module.exports = interceptor({
 
   request: function (request, config) {
     var template = request.path || config.template
-    var params = mixin({}, request.params, config.params)
+    var params = mixin({}, config.params, request.params)
 
     request.path = uriTemplate.expand(template, params)
     delete request.params

--- a/test/interceptor/template-test.js
+++ b/test/interceptor/template-test.js
@@ -64,6 +64,15 @@
       },
       'should support interceptor wrapping': function () {
         assert(typeof template().wrap === 'function')
+      },
+      'should support config params override by request params': function () {
+        var config = { params: { lang: 'en-us', term: 'hypermedia' } }
+        var client = template(parent, config)
+
+        return client({ path: 'http://example.com/dictionary{/term:1,term}{?lang}', params: { term: 'contribution' } }).then(function (response) {
+          assert.same('http://example.com/dictionary/c/contribution?lang=en-us', response.request.path)
+          refute('params' in response.request)
+        })['catch'](fail)
       }
     })
   })


### PR DESCRIPTION
This PR changes the order the params are merged so that the template interceptor config params can be overwritten by the request params.

Before this commit the config params passed in when wrapping the client
with the template interceptor could not be overwritten by the request
params passed in when invoking the client.

By changing the order of the arguments in the interceptor/template.js
mixin function, the config params (defualt params) can be overwritten by
the request params.

The docs for template interceptor defines the config params property as:

> default params to be combined with request.params

The template config params should be a default, as in they can be overwritten by the request.params. However the template config params cannot be overwritten by the request params.

This is the behavior I expected from reading the docs:
```
var client = rest.wrap(template, { params: { lang: 'en-us', section: 'introduction' } })

client({
  path: '/example/path/{section}{?lang}',
  params: {
    section: 'glossary'
  }
})

// response.url -> /example/path/glossary?lang=en-us
```

This is current behavior:
```
var client = rest.wrap(template, { params: { lang: 'en-us', section: 'introduction' } })

client({
  path: '/example/path/{section}{?lang}',
  params: {
    section: 'glossary'
  }
})

// response.url -> /example/path/introduction?lang=en-us
```

Also in this PR:

- Update year in licence block

- Add test to confirm config params overwrite behavior

This PR passes all test.

Issue: #180 