### PR TITLE
Add a maxTries property to the retry interceptor

### DIFF
--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -797,6 +797,12 @@ Reattempts an errored request after a delay.  Attempts are scheduled after a fai
   <td>Infinity</td>
   <td>max delay in milliseconds</td>
 </tr>
+<tr>
+  <td>maxTries</td>
+  <td>optional</td>
+  <td>Infinity</td>
+  <td>max number of retries</td>
+</tr>
 </table>
 
 **Example**

--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -1127,6 +1127,7 @@ The interceptors provided with rest.js provide are also good examples.  Here are
 **Error Creators**
 
 - [rest/interceptor/errorCode](#module-rest/interceptor/errorCode)
+- [rest/interceptor/retry](#module-rest/interceptor/retry)
 - [rest/interceptor/timeout](#module-rest/interceptor/timeout)
 
 <a name="interceptor-custom-concepts-recovery"></a>


### PR DESCRIPTION
Not specifying the new parameter behaves exactly like the current retry interceptor.  Setting a value from 1 to N will attempt only N total attempts before rejecting the request with a 'maxretries' error.

Documentation updated.

Unit test added.